### PR TITLE
mark window median as missing so dplyr doesn't throw warnings (fixes #19)

### DIFF
--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -33,7 +33,8 @@ dplyr_sql_translate_env <- function(con) {
       rank         = dbplyr::win_rank("RANK"),
       dense_rank   = dbplyr::win_rank("DENSE_RANK"),
       percent_rank = dbplyr::win_rank("PERCENT_RANK"),
-      cume_dist    = dbplyr::win_rank("CUME_DIST")
+      cume_dist    = dbplyr::win_rank("CUME_DIST"),
+      median       = dbplyr::win_absent("MEDIAN")
     )
   )
 }


### PR DESCRIPTION
Hoping to sneak this in to the 0.6 release it looks like you're preparing for. The comments in #19 made me think this is an easy fix, but I'm sorry if I'm missing something.

Before this PR, most queries using dbplyr have a warning about missing window median function
``` r
library(MonetDBLite)
library(dplyr)

src <- src_monetdblite(dbdir = tempdir())
copy_to(src, mtcars)

tbl(src, "mtcars") %>%
  filter(mpg > 21)
#> Warning: Translator is missing window variants of the following aggregate functions:
#> * median

#> Warning: Translator is missing window variants of the following aggregate functions:
#> * median
#> # Source:   lazy query [?? x 11]
#> # Database: MonetDBEmbeddedConnection
#>      mpg   cyl  disp    hp  drat    wt  qsec    vs    am  gear  carb
#>    <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
#>  1  22.8     4 108      93  3.85  2.32  18.6     1     1     4     1
#>  2  21.4     6 258     110  3.08  3.22  19.4     1     0     3     1
#>  3  24.4     4 147.     62  3.69  3.19  20       1     0     4     2
#>  4  22.8     4 141.     95  3.92  3.15  22.9     1     0     4     2
#>  5  32.4     4  78.7    66  4.08  2.2   19.5     1     1     4     1
#>  6  30.4     4  75.7    52  4.93  1.62  18.5     1     1     4     2
#>  7  33.9     4  71.1    65  4.22  1.84  19.9     1     1     4     1
#>  8  21.5     4 120.     97  3.7   2.46  20.0     1     0     3     1
#>  9  27.3     4  79      66  4.08  1.94  18.9     1     1     4     1
#> 10  26       4 120.     91  4.43  2.14  16.7     0     1     5     2
#> # ... with more rows
```

After PR no warning, and here's the error when you try to a windowed median:
```r
tbl(src, "mtcars") %>%
  group_by(cyl) %>%
  mutate(mpg = median(mpg))
#> Error: Window function `MEDIAN()` is not supported by this database
```