### PR TITLE
Reduced MAX_PACKET_SIZE to match what libmapi uses

### DIFF
--- a/R/mapi.R
+++ b/R/mapi.R
@@ -1,7 +1,7 @@
 # MAPI implementation for R
 
 PROTOCOL_v9 <- 9
-MAX_PACKET_SIZE <- 8192
+MAX_PACKET_SIZE <- 8192 - 2
 
 HASH_ALGOS <- c("md5", "sha1", "crc32", "sha256", "sha512")
 


### PR DESCRIPTION
Otherwise leads to problems with certain versions of MonetDB